### PR TITLE
An experiment and minor test tweeks

### DIFF
--- a/RandomTestValues.Tests/RandomTestValuesTests.cs
+++ b/RandomTestValues.Tests/RandomTestValuesTests.cs
@@ -335,5 +335,25 @@ namespace RandomTestValues.Tests
 
             testClass.TestObject2.RObject.ShouldBeType<object>();
         }
+
+        [TestMethod]
+        public void RandomObjectExperimentOfSupportedValuesWillBePopulated()
+        {
+            var testClass = RandomTestValues.ObjectExperiment<TestObject>();
+
+            testClass.RString.ShouldNotBeDefault();
+            testClass.RDecimal.ShouldNotBeDefault();
+            testClass.RDouble.ShouldNotBeDefault();
+            testClass.RInt.ShouldNotBeDefault();
+            testClass.TestObject2.ShouldNotBeDefault();
+        }
+
+        [TestMethod]
+        public void RandomObjectExperiemntOfSupportedValuesWillReturnNullForUnDeterminable()
+        {
+            var testClass = RandomTestValues.ObjectExperiment<TestObject>();
+
+            testClass.TestObject2.RObject.ShouldBeType<object>();
+        }
     }
 }

--- a/RandomTestValues.Tests/RandomTestValuesTests.cs
+++ b/RandomTestValues.Tests/RandomTestValuesTests.cs
@@ -204,6 +204,13 @@ namespace RandomTestValues.Tests
         }
 
         [TestMethod]
+        public void RandomLongShouldNotThrowAnExceptionIfANegativeNumberIsPassed()
+        {
+            // this creates an overflow in the ulong value. Should we Math.abs(-1000) it? Or is the idea of passing a negative number nonsensical? 
+            var randomBrendan = RandomTestValues.Long(-1000);
+        }
+
+        [TestMethod]
         public void RandomULongShouldProductUniqueNumbersEachTimeItIsCalled()
         {
             var randomULong1 = RandomTestValues.ULong();
@@ -266,14 +273,14 @@ namespace RandomTestValues.Tests
         {
             var randomBools = new List<bool>();
 
-            for (int i = 0; i < 50; i++)
+            for (int i = 0; i < 1000; i++)
             {
                 randomBools.Add(RandomTestValues.Bool());
             }
 
             var listOfTrues = randomBools.Where(x => x == true);
 
-            listOfTrues.Count().ShouldBeInRange(15, 35);
+            listOfTrues.Count().ShouldBeInRange(400, 600);
         }
 
         [TestMethod]


### PR DESCRIPTION
Just a little cleanup on the unit tests. 

Also, I think this might be a cleaner way of populating properties in an object in ObjectExpreiment. It uses a dictionary of <Type, LambdaExpression>. It eliminated the need for a very large chain of if/else logic. You just add your new type to the MethodsDictorary. That is a little janky... it doesn't allow you to use optional params in the lambda expression when invoking the method you want to call.  So you have to do UInt(uint.MaxValue). 