### PR TITLE
Adds support for generating random data recursively, up to a given depth

### DIFF
--- a/RandomTestValues.Tests/RandomValueObjectTests.cs
+++ b/RandomTestValues.Tests/RandomValueObjectTests.cs
@@ -140,5 +140,43 @@ namespace RandomTestValues.Tests
             result.RecursiveProperty2.ShouldEqual(null);
             result.Int.ShouldNotBeDefault();
         }
+
+        [TestMethod]
+        public void RandomObjectWithRecursivePropertyWillGenerateChildObjectsToTheSpecifiedDepth()
+        {
+            var result = RandomValue.Object<ObjectWithRecursiveProperty>(recursiveDepth:2);
+
+            // 1 level depth
+            result.RecursiveProperty.ShouldNotBeDefault();
+            result.RecursiveProperty2.ShouldNotBeDefault();
+
+            // 2 level depth
+            result.RecursiveProperty.RecursiveProperty.ShouldNotBeDefault();
+            result.RecursiveProperty2.RecursiveProperty2.ShouldNotBeDefault();
+
+            // 3 level depth (should now be null as recursiveDepth:2)
+            result.RecursiveProperty.RecursiveProperty.RecursiveProperty.ShouldEqual(null);
+            result.RecursiveProperty2.RecursiveProperty2.RecursiveProperty2.ShouldEqual(null);
+            result.RecursiveProperty.RecursiveProperty.Int.ShouldNotBeDefault();
+            result.RecursiveProperty2.RecursiveProperty2.Int.ShouldNotBeDefault();
+        }
+
+        [TestMethod]
+        public void RandomObjectWithRecursiveListWillGenerateChildObjectsToTheSpecifiedDepth()
+        {
+            var result = RandomValue.Object<ObjectWithRecursiveList>(recursiveDepth: 2);
+
+            // 1 level depth
+            result.RecursiveList.ShouldNotBeDefault();
+            result.Int.ShouldNotBeDefault();
+
+            // 2 level depth
+            result.RecursiveList[0].RecursiveList.ShouldNotBeDefault();
+            result.RecursiveList[0].Int.ShouldNotBeDefault();
+
+            // 3 level depth (should now be null as recursiveDepth:2)
+            result.RecursiveList[0].RecursiveList[0].RecursiveList.ShouldEqual(null);
+            result.RecursiveList[0].RecursiveList[0].Int.ShouldNotBeDefault();
+        }
     }
 }

--- a/RandomTestValues.Tests/Types/ObjectWithRecursiveList.cs
+++ b/RandomTestValues.Tests/Types/ObjectWithRecursiveList.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace RandomTestValues.Tests.Types
+{
+    public class ObjectWithRecursiveList
+    {
+        public List<ObjectWithRecursiveList> RecursiveList { get; set; }
+
+        public int Int { get; set; }
+    }
+}


### PR DESCRIPTION
Allows properties, lists, and nullables that reference the same type to generate random data for those child properties, up to a given depth.

It looks quite disruptive but it's not (or at least I hope it's not). Its completely opt-in (default specifies 0 depth, so should be unchanged behavior from before), and all modified public methods use optional parameter so the public API should not have changed.

:+1::+1: for a very handy library, have been starting to use it for some of our tests and it's been super useful. But now I need support for populated recursive properties to make it useful in quite a few of my project's cases, hence this PR!