### PR TITLE
Add an overload to RandomValue.Object<T> that accepts an instance of T where T is a reference type

### DIFF
--- a/RandomTestValues/RandomTestValues.csproj
+++ b/RandomTestValues/RandomTestValues.csproj
@@ -15,8 +15,12 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <Version>2.0.5.1</Version>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Description>This project is to speed up and clean up unit testing and test driven development by returning random values.</Description>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard1.0|AnyCPU'">
+    <DefineConstants />
   </PropertyGroup>
 
   <ItemGroup>

--- a/RandomTestValues/Values/RandomValue.Object.cs
+++ b/RandomTestValues/Values/RandomValue.Object.cs
@@ -23,15 +23,20 @@ namespace RandomTestValues
         {
             var genericObject = (T)Activator.CreateInstance(typeof(T));
 
-            return Object<T>(genericObject, settings);
+            return RandomizeObject<T>(genericObject, settings);
         }
 
         public static T Object<T>(T instance, int recursiveDepth = 0) where T : class
         {
-            return Object<T>(instance, new RandomValueSettings { RecursiveDepth = recursiveDepth });
+            return RandomizeObject<T>(instance, new RandomValueSettings { RecursiveDepth = recursiveDepth });
         }
 
-        public static T Object<T>(T instance, RandomValueSettings settings)
+        public static T Object<T>(T instance, RandomValueSettings settings) where T : class
+        {
+            return RandomizeObject<T>(instance, settings);
+        }
+
+        private static T RandomizeObject<T>(T instance, RandomValueSettings settings)
         {
             var properties = typeof(T).GetRuntimeProperties().ToArray();
 

--- a/RandomTestValues/Values/RandomValue.Object.cs
+++ b/RandomTestValues/Values/RandomValue.Object.cs
@@ -23,6 +23,16 @@ namespace RandomTestValues
         {
             var genericObject = (T)Activator.CreateInstance(typeof(T));
 
+            return Object<T>(genericObject, settings);
+        }
+
+        public static T Object<T>(T instance, int recursiveDepth = 0) where T : class
+        {
+            return Object<T>(instance, new RandomValueSettings { RecursiveDepth = recursiveDepth });
+        }
+
+        public static T Object<T>(T instance, RandomValueSettings settings)
+        {
             var properties = typeof(T).GetRuntimeProperties().ToArray();
 
             foreach (var prop in properties)
@@ -39,13 +49,18 @@ namespace RandomTestValues
                     continue;
                 }
 
-                var newSettings = new RandomValueSettings { RecursiveDepth = settings.RecursiveDepth - 1, IncludeNullAsPossibleValueForNullables = settings.IncludeNullAsPossibleValueForNullables, LengthOfCollection = settings.LengthOfCollection };
+                var newSettings = new RandomValueSettings
+                {
+                    RecursiveDepth = settings.RecursiveDepth - 1,
+                    IncludeNullAsPossibleValueForNullables = settings.IncludeNullAsPossibleValueForNullables,
+                    LengthOfCollection = settings.LengthOfCollection
+                };
 
                 try
                 {
                     var method = GetMethodCallAssociatedWithType(prop.PropertyType, newSettings);
 
-                    prop.SetValue(genericObject, method, null);
+                    prop.SetValue(instance, method, null);
                 }
                 catch (Exception)
                 {
@@ -53,7 +68,7 @@ namespace RandomTestValues
                 }
             }
 
-            return genericObject;
+            return instance;
         }
     }
 }

--- a/RandomTestValues/Values/RandomValue.cs
+++ b/RandomTestValues/Values/RandomValue.cs
@@ -270,12 +270,12 @@ namespace RandomTestValues
             return type.GetTypeInfo().IsGenericTypeDefinition ? type.GetTypeInfo().GenericTypeParameters : type.GetTypeInfo().GenericTypeArguments;
         }
 
-        private static bool PropertyTypeIsRecursiveOrCircular<T>(PropertyInfo property) where T : new()
+        private static bool PropertyTypeIsRecursiveOrCircular<T>(PropertyInfo property) 
         {
             return PropertyTypeIsRecursive<T>(property); // || PropertyTypeIsCircular<T>(property);
         }
         
-        private static bool PropertyTypeIsRecursive<T>(PropertyInfo property) where T : new()
+        private static bool PropertyTypeIsRecursive<T>(PropertyInfo property)
         {
             var propertyType = property.PropertyType;
 


### PR DESCRIPTION
It allows an instance of a class to have its properties set with random values.
``` c#
var instance = new MyClass(someParameter);
RandomValue.Object<MyClass>(instance);
```
This is especially useful for classes without parameterless constructors.